### PR TITLE
Fixed false truthy statment, improved output

### DIFF
--- a/Function.Install-EXE.ps1
+++ b/Function.Install-EXE.ps1
@@ -149,7 +149,7 @@ Function Install-EXE {
         # $script:installedAppDate = $installedApps.InstallDate
         # $script:installedAppUninstallString = $installedApps.UninstallString
         
-        # Poweshell returns $null arrays that have multiple $null entires as truey. To combat this, we're 
+        # Poweshell returns $null arrays that have multiple $null entires as truthy. To combat this, we're 
         # converting the array to a string to check for the number of characters in the output string. If 
         # it was an array of $null, the characters returned here will be 0 so we can be sure application 
         # is NOT installed.

--- a/Function.Install-EXE.ps1
+++ b/Function.Install-EXE.ps1
@@ -148,7 +148,11 @@ Function Install-EXE {
         # $script:installedAppNames = $installedApps.DisplayName
         # $script:installedAppDate = $installedApps.InstallDate
         # $script:installedAppUninstallString = $installedApps.UninstallString
-        If ($installedApps) {
+        
+        # In Powershell 2 and 3 incremented $null arrays return truey. To combat this, we're converting the array to
+        # a string to check for the number of characters in the output string. If it was an array of $null, the 
+        # characters returned here will be 0 so we can be sure application is NOT installed.
+        If (($installedApps | Out-String).Length -ne 0) {
             If ($installedApps.Count -gt 1) {
                 $script:output += "Multiple applications found with the word(s) [$AppName] in the display name in Add/Remove programs. See list below..."
                 $script:output += $installedAppNames
@@ -167,6 +171,8 @@ Function Install-EXE {
         $output = $output -join "`n"
         Write-Output $output
         Break
+    } Else {
+        $output += "Confirmed [$AppName] is not installed, proceeding with installation process"
     }
 
 
@@ -249,6 +255,8 @@ Function Install-EXE {
 
     } Catch {
         $output += "Failed to download $FileDownloadLink to $InstallFilePath. Unable to proceed with install without the installer file, exiting script."
+        $output = $output -join "`n"
+        Write-Output $output
         Break
     }
 

--- a/Function.Install-EXE.ps1
+++ b/Function.Install-EXE.ps1
@@ -149,9 +149,10 @@ Function Install-EXE {
         # $script:installedAppDate = $installedApps.InstallDate
         # $script:installedAppUninstallString = $installedApps.UninstallString
         
-        # In Powershell 2 and 3 incremented $null arrays return truey. To combat this, we're converting the array to
-        # a string to check for the number of characters in the output string. If it was an array of $null, the 
-        # characters returned here will be 0 so we can be sure application is NOT installed.
+        # Poweshell returns $null arrays that have multiple $null entires as truey. To combat this, we're 
+        # converting the array to a string to check for the number of characters in the output string. If 
+        # it was an array of $null, the characters returned here will be 0 so we can be sure application 
+        # is NOT installed.
         If (($installedApps | Out-String).Length -ne 0) {
             If ($installedApps.Count -gt 1) {
                 $script:output += "Multiple applications found with the word(s) [$AppName] in the display name in Add/Remove programs. See list below..."

--- a/Function.Install-MSI.ps1
+++ b/Function.Install-MSI.ps1
@@ -140,9 +140,10 @@ Function Install-MSI {
         $script:installedAppDate = $installedApps.InstallDate
         $script:installedAppUninstallString = $installedApps.UninstallString
 
-        # In Powershell 2 and 3 incremented $null arrays return truey. To combat this, we're converting the array to
-        # a string to check for the number of characters in the output string. If it was an array of $null, the 
-        # characters returned here will be 0 so we can be sure application is NOT installed.
+        # Poweshell returns $null arrays that have multiple $null entires as truey. To combat this, we're 
+        # converting the array to a string to check for the number of characters in the output string. If 
+        # it was an array of $null, the characters returned here will be 0 so we can be sure application 
+        # is NOT installed.
         If (($installedApps | Out-String).Length -ne 0) {
             If ($installedApps.Count -gt 1) {
                 $script:output += "Multiple applications found with the word(s) [$AppName] in the display name in Add/Remove programs. See list below..."

--- a/Function.Install-MSI.ps1
+++ b/Function.Install-MSI.ps1
@@ -140,7 +140,7 @@ Function Install-MSI {
         $script:installedAppDate = $installedApps.InstallDate
         $script:installedAppUninstallString = $installedApps.UninstallString
 
-        # Poweshell returns $null arrays that have multiple $null entires as truey. To combat this, we're 
+        # Poweshell returns $null arrays that have multiple $null entires as truthy. To combat this, we're 
         # converting the array to a string to check for the number of characters in the output string. If 
         # it was an array of $null, the characters returned here will be 0 so we can be sure application 
         # is NOT installed.


### PR DESCRIPTION
-Powershell was reporting truthy on $null arrays. Evidently, when you increment $null arrays it will count the array as $true despite every item in the array being $null. To combat this, we now quickly convert the array output to a string and do a string count to check to see if it's zero since a $null array would have a 0 string length. If it is 0, count that as $null.
-Noticed there were some conditions where the script would exit without outputting $output so I added an output before all Breaks
-On the MSI installer function I found there was never a check to see if the app was already installed before it starts creating dirs and downloading files like we have in the EXE installer. Added the same check as the EXE installer so that should make this a bit more efficient.