### PR TITLE
Invoke-Output function

### DIFF
--- a/Function.Invoke-Output.ps1
+++ b/Function.Invoke-Output.ps1
@@ -20,7 +20,7 @@
   output=Here is a message.`n`nAnother message.|someField=1|anotherField=0
 
   .Example
-  # -InputString example
+  # -InputStringArray example
   $messages = @('Here is a message.', 'Another message.')
 
   Invoke-Output $messages

--- a/Function.Invoke-Output.ps1
+++ b/Function.Invoke-Output.ps1
@@ -1,6 +1,6 @@
 ﻿<#
   .Description
-  Receives either `Hashtable`, or `string array` as input and writes output as newline delimited string or a pipe delimited string using `Write-Host`
+  Receives either `Hashtable` or `string array` as input and writes output as newline delimited string or a pipe delimited string using `Write-Host`
 
   If input is `-InputObject` which expects a `Hashtable`, output will be single pipe delimited string mapping keys to values with equals sign in between key and value
 
@@ -8,10 +8,12 @@
 
   .Example
   # -InputObject example
+  $messages = @('Here is a message.', 'Another message.')
+
   $blah = @{
-    output='Here is a message.', 'Another message.'
-    someField=1
-    anotherField=0
+    output = $messages
+    someField = 1
+    anotherField = 0
   }
 
   Invoke-Output $blah

--- a/Function.Invoke-Output.ps1
+++ b/Function.Invoke-Output.ps1
@@ -1,6 +1,6 @@
 ﻿<#
   .Description
-  Receives either Hashtable, or string array as input and writes output as newline delimited string or a pipe delimited string using `Write-Host`
+  Receives either `Hashtable`, or `string array` as input and writes output as newline delimited string or a pipe delimited string using `Write-Host`
 
   If input is `-InputObject` which expects a `Hashtable`, output will be single pipe delimited string mapping keys to values with equals sign in between key and value
 

--- a/Function.Invoke-Output.ps1
+++ b/Function.Invoke-Output.ps1
@@ -1,8 +1,8 @@
 ﻿<#
   .Description
   Receives either Hashtable, string, or string array input and writes output as newline delimited string or a pipe delimited string using `Write-Host`
-  If input is -InputObject which expects a Hashtable, output will be single pipe delimited string mapping keys to values with equals sign in between key and value
-  If input is -InputString which expects a string array, output will be a single newline delimited string
+  If input is `-InputObject` which expects a `Hashtable`, output will be single pipe delimited string mapping keys to values with equals sign in between key and value
+  If input is `-InputString` which expects a `string array`, output will be a single newline delimited string
 
   .Example
   # -InputObject example

--- a/Function.Invoke-Output.ps1
+++ b/Function.Invoke-Output.ps1
@@ -4,7 +4,7 @@
 
   If input is `-InputObject` which expects a `Hashtable`, output will be single pipe delimited string mapping keys to values with equals sign in between key and value
 
-  If input is `-InputString` which expects a `string array`, output will be a single newline delimited string
+  If input is `-InputStringArray` which expects a `string array`, output will be a single newline delimited string
 
   .Example
   # -InputObject example
@@ -29,13 +29,12 @@
   Here is a message.`n`nAnother message.
 #>
 
-
 Function Invoke-Output {
   Param (
     [Parameter(Mandatory = $True, ValueFromPipeline = $True, Position = 0, ParameterSetName='Hashtable')]
     [Hashtable]$InputObject,
     [Parameter(Mandatory = $True, ValueFromPipeline = $True, Position = 0, ParameterSetName='String')]
-    [string[]]$InputString
+    [string[]]$InputStringArray
   )
 
   If ($InputObject) {
@@ -69,7 +68,7 @@ Function Invoke-Output {
     }
 
     Write-Output $out
-  } ElseIf ($InputString) {
-    Write-Output ($InputString -join "`n`n")
+  } ElseIf ($InputStringArray) {
+    Write-Output ($InputStringArray -join "`n`n")
   }
 }

--- a/Function.Invoke-Output.ps1
+++ b/Function.Invoke-Output.ps1
@@ -1,6 +1,6 @@
 ﻿<#
   .Description
-  Receives either `Hashtable` or `string array` as input and writes output as newline delimited string or a pipe delimited string using `Write-Host`
+  Receives either `Hashtable` or `string array` as input and writes output as newline delimited string or a pipe delimited string using `Write-Output`
 
   If input is `-InputObject` which expects a `Hashtable`, output will be single pipe delimited string mapping keys to values with equals sign in between key and value
 
@@ -45,7 +45,7 @@
   Invoke-Output $blah
 
   # Outputs:
-  Invoke-Output Error: Entry named 'output' is not valid because Invoke-Output can only handle hashtables with values of type [string] or [string[]] (array of strings). Entry named 'output' contained type 'Array'
+  Invoke-Output Error: Entry named 'output' is not valid because Invoke-Output can only handle hashtables with values of type [string] or [string[]] (array of strings). Entry named 'output' contained an array that contained type 'Array'
 
   output=Here is a message.`n`nAnother message.|someField=1|anotherField=0
 #>

--- a/Function.Invoke-Output.ps1
+++ b/Function.Invoke-Output.ps1
@@ -1,7 +1,9 @@
 ﻿<#
   .Description
-  Receives either Hashtable, string, or string array input and writes output as newline delimited string or a pipe delimited string using `Write-Host`
+  Receives either Hashtable, or string array as input and writes output as newline delimited string or a pipe delimited string using `Write-Host`
+
   If input is `-InputObject` which expects a `Hashtable`, output will be single pipe delimited string mapping keys to values with equals sign in between key and value
+
   If input is `-InputString` which expects a `string array`, output will be a single newline delimited string
 
   .Example

--- a/Function.Invoke-Output.ps1
+++ b/Function.Invoke-Output.ps1
@@ -1,0 +1,73 @@
+﻿<#
+  .Description
+  Receives either Hashtable, string, or string array input and writes output as newline delimited string or a pipe delimited string using `Write-Host`
+  If input is -InputObject which expects a Hashtable, output will be single pipe delimited string mapping keys to values with equals sign in between key and value
+  If input is -InputString which expects a string array, output will be a single newline delimited string
+
+  .Example
+  # -InputObject example
+  $blah = @{
+    output='Here is a message.', 'Another message.'
+    someField=1
+    anotherField=0
+  }
+
+  Invoke-Output $blah
+
+  # Outputs:
+  output=Here is a message.`n`nAnother message.|someField=1|anotherField=0
+
+  .Example
+  # -InputString example
+  $messages = @('Here is a message.', 'Another message.')
+
+  Invoke-Output $messages
+
+  # Outputs:
+  Here is a message.`n`nAnother message.
+#>
+
+
+Function Invoke-Output {
+  Param (
+    [Parameter(Mandatory = $True, ValueFromPipeline = $True, Position = 0, ParameterSetName='Hashtable')]
+    [Hashtable]$InputObject,
+    [Parameter(Mandatory = $True, ValueFromPipeline = $True, Position = 0, ParameterSetName='String')]
+    [string[]]$InputString
+  )
+
+  If ($InputObject) {
+    $out = ''
+
+    $InputObject.GetEnumerator() | ForEach-Object { $i = 1 } {
+      $value = $_.Value
+      $name = $_.Name
+
+      # We already know input is a hashtable, but we want to make sure that every item in the hashtable is either a string or an array of strings
+      If ($value.GetType().BaseType.Name -eq 'Array') {
+        ForEach ($entry in $value) {
+          If ($entry.GetType().Name -ne 'String') {
+            Write-Output "Invoke-Output Error: Entry named '$($name)' is not valid because Invoke-Output can only handle hashtables with values of type [string] or [string[]] (array of strings). Entry named '$($name)' contained type '$($entry.GetType().BaseType.Name)'`n`n"
+            $value = $value | Where-Object { $_ -ne $entry }
+          }
+        }
+
+        $value = $value -join "`n`n"
+      }
+
+      $item = "$($_.Name)=$value"
+
+      If ($i -lt $InputObject.Count) {
+        $item += '|'
+      }
+
+      $out += $item
+
+      $i++
+    }
+
+    Write-Output $out
+  } ElseIf ($InputString) {
+    Write-Output ($InputString -join "`n`n")
+  }
+}

--- a/Function.Invoke-Output.ps1
+++ b/Function.Invoke-Output.ps1
@@ -6,6 +6,8 @@
 
   If input is `-InputStringArray` which expects a `string array`, output will be a single newline delimited string
 
+  If a value of `-InputObject` is an array, and any of the array items are not strings, a warning will be written and those entries will be ignored and left out.
+
   .Example
   # -InputObject example
   $messages = @('Here is a message.', 'Another message.')
@@ -29,6 +31,23 @@
 
   # Outputs:
   Here is a message.`n`nAnother message.
+
+  .Example
+  # Invalid array item example
+  $messages = @('Here is a message.', @('not a string'), 'Another message.')
+
+  $blah = @{
+    output = $messages
+    someField = 1
+    anotherField = 0
+  }
+
+  Invoke-Output $blah
+
+  # Outputs:
+  Invoke-Output Error: Entry named 'output' is not valid because Invoke-Output can only handle hashtables with values of type [string] or [string[]] (array of strings). Entry named 'output' contained type 'Array'
+
+  output=Here is a message.`n`nAnother message.|someField=1|anotherField=0
 #>
 
 Function Invoke-Output {
@@ -50,7 +69,7 @@ Function Invoke-Output {
       If ($value.GetType().BaseType.Name -eq 'Array') {
         ForEach ($entry in $value) {
           If ($entry.GetType().Name -ne 'String') {
-            Write-Output "Invoke-Output Error: Entry named '$($name)' is not valid because Invoke-Output can only handle hashtables with values of type [string] or [string[]] (array of strings). Entry named '$($name)' contained type '$($entry.GetType().BaseType.Name)'`n`n"
+            Write-Output "Invoke-Output Error: Entry named '$($name)' is not valid because Invoke-Output can only handle hashtables with values of type [string] or [string[]] (array of strings). Entry named '$($name)' contained an array that contained type '$($entry.GetType().BaseType.Name)'`n`n"
             $value = $value | Where-Object { $_ -ne $entry }
           }
         }


### PR DESCRIPTION
Receives either `Hashtable` or `string array` as input and writes output as newline delimited string or a pipe delimited string using `Write-Output`

If input is `-InputObject` which expects a `Hashtable`, output will be single pipe delimited string mapping keys to values with equals sign in between key and value

If input is `-InputStringArray` which expects a `string array`, output will be a single newline delimited string

```
# -InputObject example
$messages = @('Here is a message.', 'Another message.')

$blah = @{
  output = $messages
  someField = 1
  anotherField = 0
}

Invoke-Output $blah

# Outputs:
output=Here is a message.`n`nAnother message.|someField=1|anotherField=0
```

```
# -InputStringArray example
$messages = @('Here is a message.', 'Another message.')

Invoke-Output $messages

# Outputs:
Here is a message.`n`nAnother message.
```

If a value of `-InputObject` is an array, and any of the array items are not strings, a warning will be written and those entries will be ignored and left out.

```
# Invalid array item example
$messages = @('Here is a message.', @('not a string'), 'Another message.')

$blah = @{
  output = $messages
  someField = 1
  anotherField = 0
}

Invoke-Output $blah

# Outputs:
Invoke-Output Error: Entry named 'output' is not valid because Invoke-Output can only handle hashtables with values of type [string] or [string[]] (array of strings). Entry named 'output' contained an array that contained type 'Array'

output=Here is a message.`n`nAnother message.|someField=1|anotherField=0
```