### PR TITLE
Handle unknown OS versions in Get-WindowsVersion and Get-Win10VersionComparison

### DIFF
--- a/Function.Get-Win10VersionComparison.ps1
+++ b/Function.Get-Win10VersionComparison.ps1
@@ -76,6 +76,10 @@ function Get-Win10VersionComparison {
         Throw "This does not appear to be a Windows 10 machine. Function 'Get-Win10VersionComparison' only supports Windows 10 machines. This is: $osName"
     }
 
+    If ($version -eq 'Unknown') {
+        Throw "This version of Windows is unknown to this script. Cannot compare. This is: $osName"
+    }
+
     # If the current version is not in the list of win 10 versions, it's not supported
     If ($currentVersionIndex -eq -1) {
         Throw "Something went wrong determining the current version of windows, it does not appear to be in the list.." +

--- a/Function.Get-WindowsVersion.ps1
+++ b/Function.Get-WindowsVersion.ps1
@@ -79,6 +79,11 @@
     } ElseIf ($osName -like 'Microsoft Windows 7*') {
         $osObject.SimplifiedName = '7'
         $osObject.Name = $osName
+    } Else {
+        $osObject.Name = $osName
+        $osObject.SimplifiedName = $osName
+        $osObject.Build = 'Unknown'
+        $osObject.Version = 'Unknown'
     }
 
     Return $osObject


### PR DESCRIPTION
Add a default case to `Get-WindowsVersion` and `Throw` from `Get-Win10VersionComparison` if OS is unknown.