### PR TITLE
fix invoke-output issue

### DIFF
--- a/Function.Invoke-Output.ps1
+++ b/Function.Invoke-Output.ps1
@@ -59,6 +59,8 @@ Function Invoke-Output {
     [Parameter(Mandatory = $True, ValueFromPipeline = $True, Position = 0, ParameterSetName = 'Hashtable')]
     [Hashtable]$InputObject,
     [Parameter(Mandatory = $True, ValueFromPipeline = $True, Position = 0, ParameterSetName = 'String')]
+    [AllowEmptyCollection()]
+    [AllowNull()]
     [string[]]$InputStringArray
   )
 


### PR DESCRIPTION
Invoke-Output errors when an array item is null or when array is empty. It should not. It should only error when no argument is passed.