### PR TITLE
Windows 7/2012 password length fix

### DIFF
--- a/Library.Users.ps1
+++ b/Library.Users.ps1
@@ -42,7 +42,7 @@ Function New-LocalUserMaker ($UserName, $Pass) {
     If (Get-LocalUserExists $UserName) { Write-Output "Not creating new user $UserName because a user with that name already exists."; Return; }
 
     If ($psVers -lt 5.1) {
-        &cmd.exe /c "net user /add $UserName $Pass"
+        &cmd.exe /c "net user /add $UserName $Pass /Y"
 
         # Verify that the user was actually created
         If (!(Get-LocalUserExists $UserName)) {


### PR DESCRIPTION
In Windows 7/2012 or older, if the password is more than 14 characters you need to accept a prompt it gives you to allow the longer than 14 character password. You can do this by passing in `/Y` on the net user /add command.

Error Message:
The password entered is longer than 14 characters. Computers with Windows prior to Windows 2000 will not be able to use this account. Do you want to continue this operation? (Y/N) [Y]: