### PR TITLE
Added support for 2012 14char+ passwords

### DIFF
--- a/Library.Users.ps1
+++ b/Library.Users.ps1
@@ -42,7 +42,7 @@ Function New-LocalUserMaker ($UserName, $Pass) {
     If (Get-LocalUserExists $UserName) { Write-Output "Not creating new user $UserName because a user with that name already exists."; Return; }
 
     If ($psVers -lt 5.1) {
-        &cmd.exe /c "net user /add $UserName $Pass"
+        &cmd.exe /c "net user /add $UserName $Pass /y"
 
         # Verify that the user was actually created
         If (!(Get-LocalUserExists $UserName)) {


### PR DESCRIPTION
In Server 2012 if you want a password longer than 14 characters you have to include `/y` to the `net user` command.